### PR TITLE
Improvements to NormalisedSumPDF

### DIFF
--- a/framework/include/DebugClass.h
+++ b/framework/include/DebugClass.h
@@ -28,12 +28,6 @@ class DebugClass
 
 		//	HelperFunctions within this Sentinel
 
-		#ifndef __CINT__
-			static void SegFault() __attribute__ ((noreturn));
-		#else
-			static void SegFault();
-		#endif
-
 		template<class T> static void Dump2File( const string fileName, const vector<T> objects );
 
 		template<class T> static void Dump2TTree( const string fileName, const vector<T> objects, const string ttreeName="", const string branchName="" );

--- a/framework/include/NormalisedSumPDF.h
+++ b/framework/include/NormalisedSumPDF.h
@@ -17,10 +17,12 @@
 #include "RapidFitIntegrator.h"
 #include "ComponentRef.h"
 //	System Headers
+#include <array>
 #include <vector>
 #include <string>
 #include <map>
 
+using std::array;
 using std::vector;
 using std::string;
 using std::map;
@@ -76,6 +78,10 @@ class NormalisedSumPDF : public BasePDF
 		bool GetCachingEnabled() const;
 
 		void SetCachingEnabled( bool Input );
+
+		array<double,2> GetCachedIntegrals(DataPoint*, PhaseSpaceBoundary* ) const;
+
+		void SetCachedIntegrals(array<double,2>, DataPoint*, PhaseSpaceBoundary* );
 
 		string XML() const;
 

--- a/framework/include/NormalisedSumPDF.h
+++ b/framework/include/NormalisedSumPDF.h
@@ -92,7 +92,9 @@ class NormalisedSumPDF : public BasePDF
 		NormalisedSumPDF& operator=(const NormalisedSumPDF&);
 		void MakePrototypes( PhaseSpaceBoundary* );
 
+		double GetFirstIntegral( DataPoint* );
 		double firstIntegral;
+		double GetSecondIntegral( DataPoint* );
 		double secondIntegral;
 
 		vector<string> prototypeDataPoint, prototypeParameterSet, doNotIntegrateList;

--- a/framework/include/NormalisedSumPDF.h
+++ b/framework/include/NormalisedSumPDF.h
@@ -20,7 +20,8 @@
 #include <vector>
 #include <string>
 
-using namespace::std;
+using std::vector;
+using std::string;
 
 class NormalisedSumPDF : public BasePDF
 {
@@ -91,8 +92,8 @@ class NormalisedSumPDF : public BasePDF
 		NormalisedSumPDF& operator=(const NormalisedSumPDF&);
 		void MakePrototypes( PhaseSpaceBoundary* );
 
-		double GetFirstIntegral( DataPoint* );
-		double GetSecondIntegral( DataPoint* );
+		double firstIntegral;
+		double secondIntegral;
 
 		vector<string> prototypeDataPoint, prototypeParameterSet, doNotIntegrateList;
 		IPDF * firstPDF;
@@ -102,6 +103,7 @@ class NormalisedSumPDF : public BasePDF
 		PhaseSpaceBoundary * integrationBoundary;
 
 		bool _plotComponents;
+		bool inEvaluate = false;
 };
 
 #endif

--- a/framework/include/NormalisedSumPDF.h
+++ b/framework/include/NormalisedSumPDF.h
@@ -19,9 +19,11 @@
 //	System Headers
 #include <vector>
 #include <string>
+#include <map>
 
 using std::vector;
 using std::string;
+using std::map;
 
 class NormalisedSumPDF : public BasePDF
 {
@@ -92,10 +94,9 @@ class NormalisedSumPDF : public BasePDF
 		NormalisedSumPDF& operator=(const NormalisedSumPDF&);
 		void MakePrototypes( PhaseSpaceBoundary* );
 
-		double GetFirstIntegral( DataPoint* );
-		double firstIntegral;
-		double GetSecondIntegral( DataPoint* );
-		double secondIntegral;
+		double GetFirstIntegral( DataPoint* ) const;
+		double GetSecondIntegral( DataPoint* ) const;
+		map<unsigned int, double> firstIntegral, secondIntegral;
 
 		vector<string> prototypeDataPoint, prototypeParameterSet, doNotIntegrateList;
 		IPDF * firstPDF;

--- a/framework/include/PhaseSpaceBoundary.h
+++ b/framework/include/PhaseSpaceBoundary.h
@@ -20,7 +20,8 @@
 #include <vector>
 #include <string>
 
-using namespace::std;
+using std::vector;
+using std::string;
 
 class IPDF;
 
@@ -66,6 +67,9 @@ class PhaseSpaceBoundary
 		size_t GetID() const;
 
 		void ClearDiscreteCombinations();
+
+		bool operator==(const PhaseSpaceBoundary&) const;
+		bool operator!=(const PhaseSpaceBoundary&) const;
 
 	private:
 		PhaseSpaceBoundary& operator=(const PhaseSpaceBoundary&);

--- a/framework/include/Threading.h
+++ b/framework/include/Threading.h
@@ -21,7 +21,7 @@ class IDataSet;
 struct Fitting_Thread{
 	explicit Fitting_Thread() :
 		dataSubSet(), fittingPDF(NULL), useWeights(false), dataPoint_Result(), FitBoundary(NULL),
-		stored_integral(0.), weightsSquared(false), dataSet(NULL), thisComponent(NULL)
+		stored_integral(), weightsSquared(false), dataSet(NULL), thisComponent(NULL)
 	{}
 
 	vector<DataPoint*> dataSubSet;		/*!	DataPoints to be evaluated by this thread		*/
@@ -30,7 +30,7 @@ struct Fitting_Thread{
 	bool useWeights;			/*!	Are we performing a weighted fit?			*/
 	vector<double> dataPoint_Result;	/*!	Result for evaluating each datapoint			*/
 	PhaseSpaceBoundary* FitBoundary;	/*!	PhaseSpaceBoundary containing all data			*/
-	double stored_integral;			/*!	Stored Integral for Numerical Integral fits		*/
+	std::map<int,double> stored_integral;			/*!	Stored Integral for Numerical Integral fits		*/
 	bool weightsSquared;			/*!	Are we using Weight Squared?				*/
 
 	ComponentRef* thisComponent;

--- a/framework/src/ComponentPlotter.cpp
+++ b/framework/src/ComponentPlotter.cpp
@@ -49,7 +49,11 @@
 #endif
 #define DOUBLE_TOLERANCE 1E-6
 
-using namespace::std;
+using std::stringstream;
+using std::setw;
+using std::setprecision;
+using std::flush;
+using std::left;
 
 //Constructor with correct arguments
 ComponentPlotter::ComponentPlotter( IPDF * NewPDF, IDataSet * NewDataSet, TString PDFStr, TFile* filename, string ObservableName, CompPlotter_config* config, int PDF_Num ) :
@@ -131,7 +135,8 @@ ComponentPlotter::ComponentPlotter( IPDF * NewPDF, IDataSet * NewDataSet, TStrin
 
 	boundary_min = full_boundary->GetConstraint( observableName )->GetMinimum();
 	boundary_max = full_boundary->GetConstraint( observableName )->GetMaximum();
-
+	if(config->xmax > -99999) boundary_max = config->xmax;
+	if(config->xmin > -99999) boundary_min = config->xmin;
 	step_size = ( boundary_max - boundary_min ) / (double)( total_points - 1 );
 
 	//Work out what to plot
@@ -208,6 +213,13 @@ ComponentPlotter::ComponentPlotter( IPDF * NewPDF, IDataSet * NewDataSet, TStrin
 	if( config != NULL )
 	{
 		if( !config->combination_names.empty() ) combinationDescriptions = config->combination_names;
+	}
+
+	// Hack to get the internal cached values for NormalisedSumPDF to work
+	if(plotPDF->GetName()=="NormalisedSumPDF")
+	{
+		for(auto combination: allCombinations)
+			plotPDF->GetPDFIntegrator()->Integral( combination, full_boundary );
 	}
 
 	for( unsigned int i=0; i< allCombinations.size(); ++i )
@@ -1896,7 +1908,7 @@ double ComponentPlotter::operator() (double *x, double *p)
 
 	delete comp_obj;
 
-	cout << "Value At: " << left << setw(5) << setprecision(3) << x[0] << "\tis:\t" << setprecision(4) << integral_value << setw(20) << " " <<  "\r" << flush;
+	cout << "Value At: " << left << setw(5) << setprecision(3) << x[0] << "\t is:\t" << setprecision(4) << integral_value << setw(20) << " " <<  "\r" << flush;
 
 	return integral_value;
 }

--- a/framework/src/DataPoint.cpp
+++ b/framework/src/DataPoint.cpp
@@ -132,10 +132,7 @@ Observable* DataPoint::GetObservable(string const Name, const bool silence )
 	if( nameIndex == -1 )
 	{
 		if( !silence ) cerr << "Observable name " << Name << " not found (2)" << endl;
-		DebugClass::SegFault();
-		//this->Print();
 		throw(-1543);
-		//return new Observable( Name, 0.0, 0.0, "NameNotFoundError");
 	}
 	else
 	{
@@ -155,7 +152,6 @@ Observable* DataPoint::GetObservable( const ObservableRef& object, const bool si
 		return &(allObservables[ (unsigned) object.GetIndex() ]);
 	}
 	if( !silence ) cerr << "Observable name " << object.Name().c_str() << " not found (3)" << endl;
-	//DebugClass::SegFault();
 	throw(-20);
 }
 
@@ -168,7 +164,6 @@ bool DataPoint::SetObservable( string Name, Observable * NewObservable )
 	{
 		cerr << "Observable name " << Name << " not found (4)" << endl;
 		throw(438);
-		//return false;
 	}
 	else
 	{

--- a/framework/src/DebugClass.cpp
+++ b/framework/src/DebugClass.cpp
@@ -63,12 +63,6 @@ bool DebugClass::DebugThisClass( const string& name )
 	return false;
 }
 
-void DebugClass::SegFault()
-{
-	int *p = NULL;
-	*p = 1;
-}
-
 template<class T> void DebugClass::Dump2File( const string fileName, const vector<T> objects )
 {
 	stringstream fileContent;

--- a/framework/src/NegativeLogLikelihoodNumerical.cpp
+++ b/framework/src/NegativeLogLikelihoodNumerical.cpp
@@ -22,6 +22,7 @@
 #include "RooMath.h"
 //	RapidFit Headers
 #include "NegativeLogLikelihoodNumerical.h"
+#include "NormalisedSumPDF.h"
 #include "ClassLookUp.h"
 //	System Headers
 #include <stdlib.h>
@@ -33,7 +34,6 @@
 #include "TFile.h"
 #include "TNtuple.h"
 
-using namespace::std;
 
 pthread_mutex_t _n_eval_lock;
 pthread_mutex_t _n_int_lock;
@@ -56,6 +56,13 @@ double NegativeLogLikelihoodNumerical::EvaluateDataSet( IPDF * FittingPDF, IData
 
 	//	Have to provide a datapoint even though one is _not_ expected to be explicitly used for this fittting function
 	double this_integral = FittingPDF->GetPDFIntegrator()->Integral( TotalDataSet->GetDataPoint(0), TotalDataSet->GetBoundary() );
+
+	if(FittingPDF->GetName()=="NormalisedSumPDF")
+	{
+		std::array<double,2> IntegralResult = static_cast<NormalisedSumPDF*>(FittingPDF)->GetCachedIntegrals(TotalDataSet->GetDataPoint(0), TotalDataSet->GetBoundary());
+		for(auto PDF: stored_pdfs)
+			static_cast<NormalisedSumPDF*>(PDF)->SetCachedIntegrals(IntegralResult, TotalDataSet->GetDataPoint(0), TotalDataSet->GetBoundary());
+	}
 
 	if( TotalDataSet->GetDataNumber() == 0 ) return 0.;
 

--- a/framework/src/NormalisedSumPDF.cpp
+++ b/framework/src/NormalisedSumPDF.cpp
@@ -304,6 +304,11 @@ bool NormalisedSumPDF::SetPhysicsParameters( ParameterSet * NewParameterSet )
 //Return the integral of the function over the given boundary
 double NormalisedSumPDF::Normalisation( DataPoint* NewDataPoint, PhaseSpaceBoundary * NewBoundary )
 {
+	// Check we're working with the same boundary, otherwise the local stored integrals might not be valid
+	if((*NewBoundary) != (*integrationBoundary))
+	{
+		cerr << "The boundary passed to NormalisedSumPDF::Normalisation doesn't match the stored integrationBoundary!" << endl;
+	}
 	// Calculate and cache the integrals
 	double firstIntegralResult = firstPDF->Integral( NewDataPoint, NewBoundary ) * firstIntegralCorrection;
 	double secondIntegralResult = secondPDF->Integral( NewDataPoint, NewBoundary ) * secondIntegralCorrection;

--- a/framework/src/NormalisedSumPDF.cpp
+++ b/framework/src/NormalisedSumPDF.cpp
@@ -475,8 +475,7 @@ void NormalisedSumPDF::SetCachingEnabled( bool input )
 
 bool NormalisedSumPDF::GetCachingEnabled() const
 {
-//	return firstPDF->GetCachingEnabled() && secondPDF->GetCachingEnabled();
-	return false; // We always want Normalisation() to be called in order to update the local cached values of the component PDF integrals
+	return firstPDF->GetCachingEnabled() && secondPDF->GetCachingEnabled();
 }
 
 void NormalisedSumPDF::SetCachedIntegrals(array<double,2> IntegralResult, DataPoint* NewDataPoint, PhaseSpaceBoundary* NewBoundary)

--- a/framework/src/NormalisedSumPDF.cpp
+++ b/framework/src/NormalisedSumPDF.cpp
@@ -341,6 +341,24 @@ double NormalisedSumPDF::Evaluate( DataPoint* NewDataPoint )
 	return termOne + termTwo;
 }
 
+double NormalisedSumPDF::GetFirstIntegral( DataPoint* NewDataPoint )
+{
+	if(firstPDF->GetNumericalNormalisation())
+	{
+		return firstIntegral;
+	}
+	return firstPDF->Integral( NewDataPoint, integrationBoundary ) * firstIntegralCorrection;
+}
+
+double NormalisedSumPDF::GetSecondIntegral( DataPoint* NewDataPoint )
+{
+	if(secondPDF->GetNumericalNormalisation())
+	{
+		return secondIntegral;
+	}
+	return secondPDF->Integral( NewDataPoint, integrationBoundary ) * secondIntegralCorrection;
+}
+
 //Return the function value at the given point
 double NormalisedSumPDF::EvaluateForNumericIntegral( DataPoint * NewDataPoint )
 {
@@ -367,24 +385,6 @@ double NormalisedSumPDF::EvaluateForNumericIntegral( DataPoint * NewDataPoint )
 	//Return the sum
 	inEvaluate = false;
 	return termOne + termTwo;
-}
-
-double NormalisedSumPDF::GetFirstIntegral( DataPoint* NewDataPoint )
-{
-	if(firstPDF->GetNumericalNormalisation())
-	{
-		return firstIntegral;
-	}
-	return firstPDF->Integral( NewDataPoint, integrationBoundary ) * firstIntegralCorrection;
-}
-
-double NormalisedSumPDF::GetSecondIntegral( DataPoint* NewDataPoint )
-{
-	if(secondPDF->GetNumericalNormalisation())
-	{
-		return secondIntegral;
-	}
-	return secondPDF->Integral( NewDataPoint, integrationBoundary ) * secondIntegralCorrection;
 }
 
 //Return a prototype data point

--- a/framework/src/NormalisedSumPDF.cpp
+++ b/framework/src/NormalisedSumPDF.cpp
@@ -306,15 +306,10 @@ bool NormalisedSumPDF::SetPhysicsParameters( ParameterSet * NewParameterSet )
 //Return the integral of the function over the given boundary
 double NormalisedSumPDF::Normalisation( DataPoint* NewDataPoint, PhaseSpaceBoundary * NewBoundary )
 {
-	(void)NewDataPoint;
-	(void)NewBoundary;
 	// Calculate and cache the integrals
-	for(DataPoint* pdp: integrationBoundary->GetDiscreteCombinations())
-	{
-		unsigned int DPindex = integrationBoundary->GetDiscreteIndex(pdp);
-		firstIntegral[DPindex] = firstPDF->Integral( pdp, integrationBoundary ) * firstIntegralCorrection;
-		secondIntegral[DPindex] = secondPDF->Integral( pdp, integrationBoundary ) * secondIntegralCorrection;
-	}
+	unsigned int DPindex = NewBoundary->GetDiscreteIndex(NewDataPoint);
+	firstIntegral[DPindex] = firstPDF->Integral( NewDataPoint, NewBoundary ) * firstIntegralCorrection;
+	secondIntegral[DPindex] = secondPDF->Integral( NewDataPoint, NewBoundary ) * secondIntegralCorrection;
 	//The evaluate method already returns a normalised value
 	return 1.0;
 }

--- a/framework/src/PhaseSpaceBoundary.cpp
+++ b/framework/src/PhaseSpaceBoundary.cpp
@@ -587,7 +587,7 @@ unsigned int PhaseSpaceBoundary::GetDiscreteIndex( DataPoint* Input, const bool 
 		cerr << "This is a SERIOUS MISCONFIGURATION!!! Exiting :(" << endl;
 		Input->Print();
 		this->Print();
-		DebugClass::SegFault();
+		exit(-1);
 	}
 
 	//	Store and return the lookup of the DataPoint's index
@@ -646,5 +646,31 @@ void PhaseSpaceBoundary::CheckPhaseSpace( IPDF* toCheck ) const
 size_t PhaseSpaceBoundary::GetID() const
 {
 	return uniqueID;
+}
+
+bool PhaseSpaceBoundary::operator==(const PhaseSpaceBoundary& other) const
+{
+	unsigned numConstraints = allConstraints.size();
+	if(numConstraints != other.allConstraints.size() || GetNumberCombinations() != other.GetNumberCombinations()) return false;
+	for(unsigned iConstraint = 0; iConstraint < numConstraints; iConstraint++)
+	{
+		bool discrete = allConstraints[iConstraint]->IsDiscrete();
+		if(discrete != other.allConstraints[iConstraint]->IsDiscrete()) return false;
+		if(discrete) // both discrete, so compare GetValues
+		{// http://en.cppreference.com/w/cpp/container/vector/operator_cmp this is fine :)
+			if(allConstraints[iConstraint]->GetValues() != other.allConstraints[iConstraint]->GetValues()) return false;
+		}
+		else // both continuous, so compare GetMinimum and GetMaximum
+		{
+			if(allConstraints[iConstraint]->GetMinimum() != other.allConstraints[iConstraint]->GetMinimum()
+			|| allConstraints[iConstraint]->GetMaximum() != other.allConstraints[iConstraint]->GetMaximum()) return false;
+		}
+	}
+	return true;
+}
+
+bool PhaseSpaceBoundary::operator!=(const PhaseSpaceBoundary& other) const
+{
+	return !((*this)==other);
 }
 

--- a/framework/src/PhaseSpaceBoundary.cpp
+++ b/framework/src/PhaseSpaceBoundary.cpp
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <stdlib.h>
 #include <cmath>
+#include <signal.h>
 
 #define DOUBLE_TOLERANCE_PHASE 1E-6
 
@@ -587,7 +588,7 @@ unsigned int PhaseSpaceBoundary::GetDiscreteIndex( DataPoint* Input, const bool 
 		cerr << "This is a SERIOUS MISCONFIGURATION!!! Exiting :(" << endl;
 		Input->Print();
 		this->Print();
-		exit(-1);
+		raise(SIGSEGV); // Deliberate segfault to get stack trace
 	}
 
 	//	Store and return the lookup of the DataPoint's index

--- a/framework/src/PhaseSpaceBoundary.cpp
+++ b/framework/src/PhaseSpaceBoundary.cpp
@@ -504,7 +504,7 @@ unsigned int PhaseSpaceBoundary::GetDiscreteIndex( DataPoint* Input, const bool 
 	bool IDFound = Input->FindDiscreteIndexID( uniqueID );
 	if( thisIndex != -1 && IDFound ) return (unsigned)thisIndex;
 
-	if( this->GetDiscreteNames().empty() || (this->GetDiscreteNames().size() == 1) )
+	if( this->GetDiscreteNames().empty() || (this->GetDiscreteCombinations().size() == 1) )
 	{
 		Input->SetDiscreteIndexIDMap( uniqueID, 0 );
 		return 0;


### PR DESCRIPTION
Previously, it was calling `PDF->Integral()` inside `NormalisedSumPDF::Evaluate()`. This would crash hard if the component PDFs were numerically-integrated because the `MultiThreadedFunctions` class contains a static list of functions being evaluated. So the first component PDF would go to be integrated, `MultiThreadedFunctions` would decide that the list needs to be cleared, which calls the destructors on all of the `NormalisedSumPDF` objects, which in turn destroys the component PDF which was being integrated.

I made it so the integrals of the component PDFs are now member variables, which are calculated when `NormalisedSumPDF::Normalisation()` is called. (I did try on `NormalisedSumPDF::SetPhysicsParameters()` but that scaled *inversely* with number of threads...)

I also got rid of quite a bit of commented-out debug code and added a check to throw a warning when the destructor gets called during evaluation (shouldn't happen now).

----

Update 6th April 2017:  
To-do list before this can be merged

- [ ] Make this work with all `FitFunction`-derived classes
  - In particular, there is currently a bit of a hack in `NegativeLogLikelihoodNumerical` which propagates the cached component-PDF normalisation values from the 'master' PDF to the PDF objects sitting in each of the threads
  - This can be circumvented by re-working the multithreading (@kgizdov: care to comment?)
- [ ] Test with analytically-integrated PDFs
- [x] Test with discrete datasets
